### PR TITLE
Allow specification of LaTeX engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ const pdf = await pdflatex(source)
 
 ### Options
 
+#### `engine`: `string`
+
+Changes which LaTeX engine is used (such as `pdflatex`, `xelatex`, etc.).
+
+```js
+pdflatex(latexContent, { engine: 'xelatex' })
+```
+
 #### `shellEscape`: `boolean`
 
 Adds the `-shell-escape` flag during compilation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { exec, readFile, writeFile, createTempDirectory } from './utils'
 import { readErrorLog } from './readErrorLog'
 
 export type Options = {
+  engine?: string
   texInputs?: string[]
   shellEscape?: boolean
 }
@@ -35,7 +36,7 @@ const createChildEnv = (texInputs: string[] = []) =>
 
 const createCommand = (options: Options) =>
   [
-    'pdflatex',
+    options.engine == null ? 'pdflatex' : options.engine,
     ...(options.shellEscape ? ['-shell-escape'] : []),
     '-halt-on-error',
     'texput.tex'


### PR DESCRIPTION
It's sometimes useful depending on the packages being used to specify the engine.