### PR TITLE
Xelatex engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:8-alpine
+
+RUN apk add --update \ 
+--repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+--repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+--no-cache texlive-full \
+--no-cache texlive-xetex \
+--no-cache ttf-font-awesome

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ Adds paths to `TEXINPUTS` env var during compilation.
 pdflatex(latexContent, { texInputs: ['../resources/'] })
 ```
 
+#### `engine`: `string'
+
+Allows you to use a tex engine other than the default pdflatex engine.
+
+```js
+pdflatex(leatexContent, { engine: 'xelatex' }
+```
+
+**This option requires that you have the appropriate engine installed.**  See the example [Dockerfile](./Dockerfile).
 
 TypeScript
 ----------

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { readErrorLog } from './readErrorLog'
 export type Options = {
   texInputs?: string[]
   shellEscape?: boolean
+  engine?: string[]
 }
 
 /**
@@ -35,7 +36,7 @@ const createChildEnv = (texInputs: string[] = []) =>
 
 const createCommand = (options: Options) =>
   [
-    'pdflatex',
+    options.engine ? options.engine : 'pdflatex',
     ...(options.shellEscape ? ['-shell-escape'] : []),
     '-halt-on-error',
     'texput.tex'


### PR DESCRIPTION
- Adds support for different latex engines.
- Example Dockerfile for installing xelatex engine on Alpine